### PR TITLE
Automate closing and releasing Sonatype staging repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.22.0"
     }
 }
 
@@ -21,6 +22,8 @@ apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
+apply plugin: 'io.codearte.nexus-staging'
+
 
 apply plugin: 'com.github.hierynomus.license'
 

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -4,4 +4,7 @@ if [ "$TRAVIS_BRANCH" = 'main' ] && [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
 
   # upload artifacts
   ./gradlew -Psigning.password=$PASSPHRASE uploadArchives
+
+  # close and release Sonatype staging repository
+  ./gradlew closeAndReleaseRepository
 fi


### PR DESCRIPTION
Deployment to Maven Central [works](https://travis-ci.com/github/IBM/cusp/builds/213705910)!

At least, deploying to the Maven Central staging repository works:

![image](https://user-images.githubusercontent.com/298381/105193957-1b8c2480-5b07-11eb-84ed-cf32416c4948.png)

The manual process of closing the staging repository and releasing to Maven Central proper can be done manually (I've done that and am waiting for that to take effect), or can be automated using [this plugin](https://github.com/Codearte/gradle-nexus-staging-plugin/) as suggested in [Sonatype docs](https://central.sonatype.org/pages/gradle.html). This PR implements that automation.